### PR TITLE
Add a symbol reference to the `mytrades` request

### DIFF
--- a/gemini/client.py
+++ b/gemini/client.py
@@ -213,6 +213,7 @@ class Client(object):
         payload = {
             'request': self.API_VERSION + endpoint,
             'nonce': self._get_nonce(),
+            'symbol': symbol,
             'limit_trades': limit_trades,
             'timestamp': timestamp
         }


### PR DESCRIPTION
The symbol is not being referenced in the request. 

BEFORE:
```
In [5]: c = Client(api_key=key, api_secret=secret)

In [6]: c.get_past_trades("ethusd", 5)
------------------------------------------------------------------
TypeError                        Traceback (most recent call last)
<ipython-input-6-33f7ffbf8c07> in <module>()
----> 1 c.get_past_trades("ethusd", 5)

/Users/pivotal/workspace/gemini-python-unoffc/gemini/client.py in get_past_trades(self, symbol, limit_trades, timestamp)
    218         }
    219
--> 220         return self._invoke_api(endpoint, payload, pub=False)
    221
    222     # Order Placement API

/Users/pivotal/workspace/gemini-python-unoffc/gemini/client.py in _invoke_api(self, endpoint, payload, params, pub)
     76             response = requests.get(url, headers=headers, params=params)
     77
---> 78         return self._handle_response(request, response)
     79
     80     # Public API methods

/Users/pivotal/workspace/gemini-python-unoffc/gemini/client.py in _handle_response(self, request, response)
     37
     38         if not status_code.startswith('2'):
---> 39             raise raise_api_error(request, response)
     40         else:
     41             return response.json()

/Users/pivotal/workspace/gemini-python-unoffc/gemini/error.py in raise_api_error(request, response)
     78     error = api_error_map.get(response.json()['reason'])
     79
---> 80     return error(err_txt)

TypeError: 'NoneType' object is not callable
```

AFTER
```
In [6]: c.get_past_trades("ethusd", 5)
Out[6]:
[{'aggressor': False,
  'amount': '3.73502218',
...
}]
```