### PR TITLE
Fix get_past_trades and new_deposit_address calls

### DIFF
--- a/gemini/client.py
+++ b/gemini/client.py
@@ -291,7 +291,7 @@ class Client(object):
 
     def new_deposit_address(self, currency, label):
         """ https://docs.gemini.com/rest-api/#new-deposit-address """
-        endpoint = '/' + currency + '/newAddress'
+        endpoint = '/deposit/' + currency + '/newAddress'
 
         payload = {
             'request': self.API_VERSION + endpoint,

--- a/gemini/client.py
+++ b/gemini/client.py
@@ -213,6 +213,7 @@ class Client(object):
         payload = {
             'request': self.API_VERSION + endpoint,
             'nonce': self._get_nonce(),
+            'symbol': symbol,
             'limit_trades': limit_trades,
             'timestamp': timestamp
         }


### PR DESCRIPTION
get_past_trades was missing the symbol, new_deposit_address had the wrong endpoint specified.